### PR TITLE
Delete a Preference (stored locally)

### DIFF
--- a/back/routes/adventure.js
+++ b/back/routes/adventure.js
@@ -24,7 +24,7 @@ router.post('/restaurants', async(req, res) => {
   })
 })
 
-// ----- Get active user's preferences -----
+// ----- Get active user's preferences IDs -----
 router.post('/preferences/active', async(req, res) => {
   const query = new Parse.Query('UserPreference');
   query.equalTo("username", req.body.username)
@@ -34,19 +34,18 @@ router.post('/preferences/active', async(req, res) => {
 })
 
 // ----- Get all existing Preferences -----
-router.get('/preferences/all', async(req, res) => {
+router.post('/preferences/all', async(req, res) => {
   const query = new Parse.Query('Preference');
   let preferences = await query.find();
   res.status(200);
   res.send(preferences);
 })
 
-// ----- Get all inactive preferences -----
+// ----- Get all inactive preferences IDS -----
 router.post('/preferences/inactive', async(req, res) => {
-  const username = req.body.username
   // Find current preferences
   const getUserPreferenceQuery = new Parse.Query('UserPreference');
-  getUserPreferenceQuery.equalTo("username", username)
+  getUserPreferenceQuery.equalTo("username", req.body.username)
   let activePreferences = [];
   let userPreferences = await getUserPreferenceQuery.first();
   if (userPreferences != null) {
@@ -55,10 +54,10 @@ router.post('/preferences/inactive', async(req, res) => {
     const allPreferencesQuery = new Parse.Query('Preference');
     let allPreferences = null;
     allPreferences = await allPreferencesQuery.find();
-    // Find inactive preferences
+    // Find inactive preferences IDS
     let inactivePreferences = allPreferences.filter((preference) => !activePreferences.includes(preference.toJSON().objectId));
-    const inactivePreferencesJSON = inactivePreferences.map((preference) => preference.toJSON())
-    res.status(201);
+    const inactivePreferencesJSON = inactivePreferences.map((preference) => preference.toJSON().objectId)
+    res.status(200);
     res.send(inactivePreferencesJSON);
   }
 })

--- a/capstone/src/components/User/Adventurer/Preference/FilterArea/FilterArea.jsx
+++ b/capstone/src/components/User/Adventurer/Preference/FilterArea/FilterArea.jsx
@@ -1,116 +1,24 @@
-import {
-  Box, Checkbox, Badge, HStack, Slider, SliderMark, SliderTrack,
-  SliderFilledTrack, Tooltip, SliderThumb, Button, VStack,
-} from '@chakra-ui/react';
-import { StarIcon, DeleteIcon } from '@chakra-ui/icons';
+import { Box } from '@chakra-ui/react';
 import { useState } from 'react';
-
-// Top part of the filter options: set a minimum value for preference, read its name and delete it
-function FilterControls({ setShowMinimumValues, priority, displayText }) {
-  return (
-    <Box>
-      <HStack spacing="40px" mb="20px">
-        <Checkbox
-          ml="45px"
-          onChange={(e) => setShowMinimumValues(e.target.checked)}
-        />
-        <Badge> {priority} </Badge>
-        <Badge> {displayText} </Badge>
-        <Button
-          rightIcon={<DeleteIcon />}
-          colorScheme="red"
-          variant="outline"
-          alignSelf="right"
-        >
-          Delete
-        </Button>
-      </HStack>
-    </Box>
-  );
-}
-
-// Slider to control the minimum value for the preference
-function SliderControl({
-  id,
-  minValue,
-  maxValue,
-  defaultValue,
-  step,
-  units,
-}) {
-  const markSpace = maxValue / 5;
-  const [sliderValue, setSliderValue] = useState(defaultValue);
-  const [showToolTip, setShowTooltip] = useState(false);
-  return (
-    <VStack mb="40px">
-      <Badge colorScheme="yellow"> {sliderValue} <DefineIcon units={units} /> or more </Badge>
-      <Slider
-        width="80%"
-        ml="10%"
-        mt="20px"
-        mb="20px"
-        id={id}
-        defaultValue={defaultValue !== sliderValue ? sliderValue : defaultValue}
-        min={minValue}
-        max={maxValue}
-        step={step}
-        colorScheme="yellow"
-        onChange={(v) => setSliderValue(v)}
-        onMouseEnter={() => setShowTooltip(true)}
-        onMouseLeave={() => setShowTooltip(false)}
-      >
-        {[markSpace, 2 * markSpace, 3 * markSpace, 4 * markSpace, maxValue].map(
-          (interval) => (
-            <SliderMark
-              value={interval}
-              mt="1"
-              ml="-2.5"
-              fontSize="sm"
-              textAlign="center"
-            >
-              {Math.round(interval)}{' '}
-            </SliderMark>
-          ),
-        )}
-        <SliderTrack>
-          <SliderFilledTrack />
-        </SliderTrack>
-        <Tooltip
-          hasArrow
-          bg="yellow.500"
-          color="white"
-          placement="top"
-          isOpen={showToolTip}
-          label={sliderValue}
-        >
-          <SliderThumb />
-        </Tooltip>
-      </Slider>
-    </VStack>
-  );
-}
+import FilterControls from './FilterControls';
+import SliderControls from './SliderControls';
 
 export default function FilterArea({
-  id,
-  displayText,
-  priority,
-  minValue,
-  maxValue,
-  defaultValue,
-  step,
-  units,
+  id, displayText, priority, minValue, maxValue, defaultValue, step, units, handleDelete
 }) {
   const [showMinimumValues, setShowMinimumValues] = useState(false);
   return (
     <Box>
       <FilterControls
         setShowMinimumValues={setShowMinimumValues}
+        id={id}
         priority={priority}
         displayText={displayText}
+        handleDelete={handleDelete}
       />
       {showMinimumValues
         && (
-        <SliderControl
+        <SliderControls
           key={id}
           id={id}
           minValue={minValue}
@@ -123,8 +31,4 @@ export default function FilterArea({
 
     </Box>
   );
-}
-
-function DefineIcon({ units }) {
-  if (units === 'star') return <StarIcon />;
 }

--- a/capstone/src/components/User/Adventurer/Preference/FilterArea/FilterControls.jsx
+++ b/capstone/src/components/User/Adventurer/Preference/FilterArea/FilterControls.jsx
@@ -1,0 +1,29 @@
+import { DeleteIcon } from '@chakra-ui/icons';
+import { Box, Checkbox, Badge, HStack, Button } from '@chakra-ui/react';
+
+// Top part of the filter options: set a minimum value for preference, read its name and delete it
+export default function FilterControls({
+  id, setShowMinimumValues, priority, displayText, handleDelete,
+}) {
+  return (
+    <Box>
+      <HStack spacing="40px" mb="20px">
+        <Checkbox
+          ml="45px"
+          onChange={(e) => setShowMinimumValues(e.target.checked)}
+        />
+        <Badge> {priority} </Badge>
+        <Badge> {displayText} </Badge>
+        <Button
+          rightIcon={<DeleteIcon />}
+          colorScheme="red"
+          variant="outline"
+          alignSelf="right"
+          onClick={() => handleDelete(id)}
+        >
+          Delete
+        </Button>
+      </HStack>
+    </Box>
+  );
+}

--- a/capstone/src/components/User/Adventurer/Preference/FilterArea/SliderControls.jsx
+++ b/capstone/src/components/User/Adventurer/Preference/FilterArea/SliderControls.jsx
@@ -1,0 +1,71 @@
+import {
+  Badge, Slider, SliderMark, SliderTrack,
+  SliderFilledTrack, Tooltip, SliderThumb, VStack,
+} from '@chakra-ui/react';
+import { StarIcon } from '@chakra-ui/icons';
+import { useState } from 'react';
+
+function DefineIcon({ units }) {
+  if (units === 'star') return <StarIcon />;
+}
+
+// Slider to control the minimum value for the preference
+export default function SliderControls({
+  id,
+  minValue,
+  maxValue,
+  defaultValue,
+  step,
+  units,
+}) {
+  const markSpace = maxValue / 5;
+  const [sliderValue, setSliderValue] = useState(defaultValue);
+  const [showToolTip, setShowTooltip] = useState(false);
+  return (
+    <VStack mb="40px">
+      <Badge colorScheme="yellow"> {sliderValue} <DefineIcon units={units} /> or more </Badge>
+      <Slider
+        width="80%"
+        ml="10%"
+        mt="20px"
+        mb="20px"
+        id={id}
+        defaultValue={defaultValue !== sliderValue ? sliderValue : defaultValue}
+        min={minValue}
+        max={maxValue}
+        step={step}
+        colorScheme="yellow"
+        onChange={(v) => setSliderValue(v)}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        {[markSpace, 2 * markSpace, 3 * markSpace, 4 * markSpace, maxValue].map(
+          (interval) => (
+            <SliderMark
+              value={interval}
+              mt="1"
+              ml="-2.5"
+              fontSize="sm"
+              textAlign="center"
+            >
+              {Math.round(interval)}{' '}
+            </SliderMark>
+          ),
+        )}
+        <SliderTrack>
+          <SliderFilledTrack />
+        </SliderTrack>
+        <Tooltip
+          hasArrow
+          bg="yellow.500"
+          color="white"
+          placement="top"
+          isOpen={showToolTip}
+          label={sliderValue}
+        >
+          <SliderThumb />
+        </Tooltip>
+      </Slider>
+    </VStack>
+  );
+}

--- a/capstone/src/components/User/Adventurer/Preference/FilterMenu/FilterMenu.jsx
+++ b/capstone/src/components/User/Adventurer/Preference/FilterMenu/FilterMenu.jsx
@@ -3,15 +3,7 @@ import {
   Menu, MenuButton, Button, MenuList, MenuItem,
 } from '@chakra-ui/react';
 
-export default function FilterMenu({
-  inactivePreferences, setInactivePreferences, activePreferencesIDs, setActivePreferencesIDs,
-}) {
-  function handleAddition(objectId) {
-    setActivePreferencesIDs([...activePreferencesIDs, objectId]);
-    setInactivePreferences(
-      inactivePreferences.filter((preferences) => preferences.objectId !== objectId),
-    );
-  }
+export default function FilterMenu({ inactivePreferences, handleAddition }) {
   return (
     <Menu>
       <MenuButton as={Button} rightIcon={<ChevronDownIcon />} width="1000px">


### PR DESCRIPTION
I rearrange the back-end
Flow of data:

Parse stores 
- PREFERENCES: All the information
- USER-PREFERENCES: Id of the active preferences of the user

My backend retrieves that information and provides:
- An array with id of active and inactive preferences
- The information of the preference in a given array

With the front-end:
- I use states and get the current active and inactive array of ids
- I get the information of those to display it in the preferences menu or in the add dropdown
![image](https://user-images.githubusercontent.com/60989884/180511298-09899e08-5a97-4972-b061-4bd7027659d3.png)
- I change the values of states containing the identifiers, and using a useEffect, I modify another state that stores the information of the active and inactive preferences 