### PR TITLE
joined active/inactive endpoint for status in addventurer

### DIFF
--- a/capstone/src/components/User/Adventurer/Adventurer.jsx
+++ b/capstone/src/components/User/Adventurer/Adventurer.jsx
@@ -1,7 +1,5 @@
 import { useNavigate, useParams } from 'react-router-dom';
-import {
-  useEffect, useState, useMemo, useContext,
-} from 'react';
+import { useEffect, useState, useMemo, useContext } from 'react';
 import { Box, HStack } from '@chakra-ui/react';
 import axios from 'axios';
 import FindAdventure from './FindAdventure/FindAdventure';
@@ -68,10 +66,10 @@ export default function Adventurer({ setIsLoggedIn, isLoggedIn }) {
   // Fetch restaurants
   useEffect(() => {
     if (
-      currentPosition.lat === 0
-      || currentPosition.lng === 0
-      || params.page !== 'home'
-      || !username
+      currentPosition.lat === 0 ||
+      currentPosition.lng === 0 ||
+      params.page !== 'home' ||
+      !username
     ) {
       setRestaurants([]);
     } else {
@@ -88,8 +86,14 @@ export default function Adventurer({ setIsLoggedIn, isLoggedIn }) {
         setIsDataFetched(true);
       });
     }
-  }, [currentPosition, setCurrentPosition, setRestaurants, params, username, setFeedbackInfo]);
-
+  }, [
+    currentPosition,
+    setCurrentPosition,
+    setRestaurants,
+    params,
+    username,
+    setFeedbackInfo,
+  ]);
   if (params.page === 'home') {
     return (
       <Box height="55vw">
@@ -98,9 +102,7 @@ export default function Adventurer({ setIsLoggedIn, isLoggedIn }) {
           <FeedbackContext.Provider value={feedbackInfo}>
             <HStack height="100%">
               <FindAdventure />
-              <ExperienceInfo
-                onSubmit={setRestaurants}
-              />
+              <ExperienceInfo onSubmit={setRestaurants} />
             </HStack>
           </FeedbackContext.Provider>
         </AdventurerContext.Provider>
@@ -111,9 +113,9 @@ export default function Adventurer({ setIsLoggedIn, isLoggedIn }) {
     return (
       <div className="user">
         <Header onLogOutClick={setIsLoggedIn} userType="adventurer" />
-        <div className="filters">
+        <FeedbackContext.Provider value={feedbackInfo}>
           <Preference />
-        </div>
+        </FeedbackContext.Provider>
       </div>
     );
   }

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
@@ -37,8 +37,8 @@ export default function ExperienceInfo({ onSubmit }) {
   const isRated = currentRestaurant?.review != null;
   // Get the information for the active feedback areas
   // discarding distance (that is not to be rated forExperience)
-  const feedbackAreas = feedbackInfo.filter((feedback) =>
-    feedback.forExperience && currentRestaurant.activeFeedback.includes(feedback.objectId),
+  const feedbackAreas = feedbackInfo?.filter((feedback) =>
+    feedback.forExperience && currentRestaurant?.activeFeedback.includes(feedback.objectId),
   );
   // find the photo reference of that restaurant
   const photoReference = currentRestaurant

--- a/capstone/src/components/User/Adventurer/Preference/FilterArea/SliderControls.jsx
+++ b/capstone/src/components/User/Adventurer/Preference/FilterArea/SliderControls.jsx
@@ -57,6 +57,7 @@ export default function SliderControls({
         {[markSpace, 2 * markSpace, 3 * markSpace, 4 * markSpace, maxValue].map(
           (interval) => (
             <SliderMark
+              key={`${id}mark${interval}`}
               value={interval}
               mt="1"
               ml="-2.5"

--- a/capstone/src/components/User/Adventurer/Preference/Preference.jsx
+++ b/capstone/src/components/User/Adventurer/Preference/Preference.jsx
@@ -12,14 +12,16 @@ import { useContext } from 'react';
 import FilterArea from './FilterArea/FilterArea';
 import SelectMenu from '../../SelectMenu';
 import UserContext from '../../../../Contexts/UserContext';
+import FeedbackContext from '../../../../Contexts/FeedbackContext';
 import useSettings from '../../useSettings';
 
 export default function Preference() {
   const { username, userType } = useContext(UserContext);
+  const feedbackInfo = useContext(FeedbackContext);
   if (username == null || userType == null) return <h2>Loading...</h2>;
   const {
-    activeInfo,
-    inactiveInfo,
+    activeIDs,
+    inactiveIDs,
     onSwitchChange,
     prioritize,
     onAdd,
@@ -30,6 +32,15 @@ export default function Preference() {
     onChangeHasMinValue,
     onChangeMinValue,
   } = useSettings(userType, username);
+  if (!feedbackInfo) return <h2>Loading</h2>;
+  // Find the information of the active and inactive IDs
+  // Map function so it respects the order it is in
+  const activeInfo = activeIDs.map((ID) =>
+    feedbackInfo.find((feedback) => ID === feedback.objectId),
+  );
+  const inactiveInfo = feedbackInfo.filter((feedback) =>
+    inactiveIDs.includes(feedback.objectId),
+  );
   return (
     <HStack>
       <Box bg="gray.100" width="50%">


### PR DESCRIPTION
Hi everyone! 

A bit of context for this PR.
I basically had this two endpoints to get an array of IDs of inactive and active preferences. 
What I would do is that I would get that array for the user (making the request to the middleware to the db and back), so that I would later call another endpoint that given an array of IDs, returns the information of those keys (again, from UI through middleware to db and back)

**ADVENTURE.JS**

To improve it I decided to have this one endpoint that returns both keys in one call, so it gets you back an object with the format { active : ['feedbackID', ....], inactive: [...] }, and with the help of the endpoint found in the https://github.com/carlosvegap/capstone-kickoff/pull/60, I would just filter the data in the UI. In other words, with this PR I have the array of keys, with the previous I get all data and I apply a filter.

The preferences/update route still works, so I just need to refactor it the way I was doing it, with queries on its corresponding doc.

**ADVENTURER.JSX**

Sorry, I just realized that Prettier and ESlint are in disagreement on the rules that made most of the changes on this file. 
The only thing is that I added a Provider to my Feedback context so that I can do the filtering that I mentioned in the first part of Adventure.js

**PREFERENCE.JSX**

I consume the context and I added the filtering that I mentioned. For active preferences I had to do a map of the keys and then find that key within the feedbackInfo, so that the order in which my activeFeedback array is structured is preserved (that is the order that the user has setted)

**USESETTINGS.JSX**

Finally in my custom hook I changed the structured so that it matched what was required and would be generated from my endpoint in Adventure.js


Thanks for the help!!