### PR TITLE
Refactor BackEnd Adventure for Rating Experiences

### DIFF
--- a/back/queries/adventure.js
+++ b/back/queries/adventure.js
@@ -46,8 +46,31 @@ async function ExperiencesQuery() {
   );
 }
 
+// Submit a review by an adventurer and return success or fail
+// Used by /routes/adventure/rate
+async function RateQuery(reviews, username, experienceId) {
+  let hasError = false;
+  await Promise.all(
+    reviews.map(async (review) => {
+      const newReview = new Parse.Object('Review');
+      newReview.set('feedbackId', review.feedbackId);
+      newReview.set('adventurerUsername', username);
+      newReview.set('experienceId', experienceId);
+      newReview.set('score', review.score);
+      newReview.set('comment', review.comment);
+      try {
+        await newReview.save();
+      } catch (err) {
+        hasError = true;
+      }
+    }),
+  );
+  return hasError;
+}
+
 exports.ExperienceReviewsQuery = ExperienceReviewsQuery;
 exports.UserPreferencesQuery = UserPreferencesQuery;
 exports.AllFeedbackInfoQuery = AllFeedbackInfoQuery;
 exports.UserReviewsQuery = UserReviewsQuery;
 exports.ExperiencesQuery = ExperiencesQuery;
+exports.RateQuery = RateQuery;

--- a/back/routes/adventure.js
+++ b/back/routes/adventure.js
@@ -168,15 +168,9 @@ router.get('/preferences/status', async (req, res) => {
     const inactivePreferencesIDs = inactivePreferences.map(
       (preference) => preference.objectId,
     );
-    res
-      .status(200)
-      .send({ active: activePreferencesIDs, inactive: inactivePreferencesIDs });
+    res.status(200).send({ active: activePreferencesIDs, inactive: inactivePreferencesIDs });
   } else {
-    res
-      .status(400)
-      .send({
-        error: { message: 'No existing preferences record for that user' },
-      });
+    res.status(400).send({ error: { message: 'No existing preferences record for that user' }});
   }
 });
 

--- a/back/routes/adventure.js
+++ b/back/routes/adventure.js
@@ -5,6 +5,7 @@ const {
   AllFeedbackInfoQuery,
   UserReviewsQuery,
   ExperiencesQuery,
+  RateQuery,
 } = require('../queries/adventure');
 const { filterAndRank } = require('../functions/adventure');
 var express = require('express');
@@ -164,11 +165,32 @@ router.get('/preferences/status', async (req, res) => {
     const inactivePreferences = allFeedback.filter(
       (feedback) => !activePreferencesIDs.includes(feedback.objectId),
     );
-    const inactivePreferencesIDs = inactivePreferences.map((preference) => preference.objectId)
-    res.status(200).send({ active: activePreferencesIDs, inactive: inactivePreferencesIDs });
+    const inactivePreferencesIDs = inactivePreferences.map(
+      (preference) => preference.objectId,
+    );
+    res
+      .status(200)
+      .send({ active: activePreferencesIDs, inactive: inactivePreferencesIDs });
   } else {
-    res.status(400).send({ error : { message: "No existing preferences record for that user" }})
+    res
+      .status(400)
+      .send({
+        error: { message: 'No existing preferences record for that user' },
+      });
   }
+});
+
+// -_-_-_-_-_-_-_ENDPOINT_-_-_-_-_-_-_-_-_-_
+// ----- Submit a review ------
+// Used in ExperienceInfo.jsx
+// Returns a bool with submission status
+router.post('/rate', async (req, res) => {
+  const hasError = RateQuery(
+    req.body.reviews,
+    req.headers.username,
+    req.headers.experienceid,
+  );
+  res.status(200).send(hasError);
 });
 
 /* 
@@ -266,7 +288,5 @@ router.post('/preferences/info', async (req, res) => {
   res.status(200);
   res.send(preferenceInformationJSON);
 });
-
-
 
 module.exports = router;

--- a/back/routes/review.js
+++ b/back/routes/review.js
@@ -30,31 +30,6 @@ router.post('/isRated', async (req, res) => {
   }
 });
 
-// ----- Submit a review -----
-router.post('/rate', async (req, res) => {
-  let hasError = false;
-  await Promise.all(
-    req.body.reviews.map(async (adventurerReview) => {
-      const review = new Parse.Object('Review');
-      review.set('feedbackId', adventurerReview.feedbackId);
-      review.set('adventurerUsername', req.body.username);
-      review.set('experienceId', req.body.experienceId);
-      review.set('score', adventurerReview.score);
-      review.set('comment', adventurerReview.comment);
-      try {
-        await review.save();
-      } catch (err) {
-        hasError = true;
-      }
-    }),
-  );
-  if (hasError) {
-    res.status(400).send(false);
-  } else {
-    res.status(200).send(true);
-  }
-});
-
 // Query for all reviews
 async function getReviews(experienceId) {
   const query = new Parse.Query('Review');

--- a/capstone/.eslintrc.json
+++ b/capstone/.eslintrc.json
@@ -26,6 +26,8 @@
         "implicit-arrow-linebreak": "off",
         "function-paren-newline": "off",
         "no-param-reassign": "off",
-        "no-shadow": "off"
+        "no-shadow": "off",
+        "operator-linebreak": "off",
+        "object-curly-newline": "off"
     }
 }

--- a/capstone/src/components/User/Adventurer/Adventurer.jsx
+++ b/capstone/src/components/User/Adventurer/Adventurer.jsx
@@ -102,7 +102,7 @@ export default function Adventurer({ setIsLoggedIn, isLoggedIn }) {
           <FeedbackContext.Provider value={feedbackInfo}>
             <HStack height="100%">
               <FindAdventure />
-              <ExperienceInfo onSubmit={setRestaurants} />
+              <ExperienceInfo onUpdateRestaurants={setRestaurants} />
             </HStack>
           </FeedbackContext.Provider>
         </AdventurerContext.Provider>

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
@@ -44,10 +44,8 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
   const isRated = currentRestaurant ? currentRestaurant.review != null : false;
   // Get the information for the active feedback areas
   // discarding distance (that is not to be rated forExperience)
-  const feedbackAreas = feedbackInfo?.filter(
-    (feedback) =>
-      feedback.forExperience &&
-      currentRestaurant?.activeFeedback.includes(feedback.objectId),
+  const feedbackAreas = feedbackInfo?.filter((feedback) =>
+    feedback.forExperience && currentRestaurant?.activeFeedback.includes(feedback.objectId),
   );
   // find the photo reference of that restaurant
   const photoReference = currentRestaurant
@@ -101,10 +99,7 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
     submitRate(username, currentRestaurant.place_id, newReview).then((res) => {
       if (res.data) {
         // update value of Restaurants in the useContext
-        onUpdateRestaurants([
-          ...restaurants,
-          { ...currentRestaurant, review: newReview },
-        ]);
+        onUpdateRestaurants([...restaurants, { ...currentRestaurant, review: newReview }]);
         return toast({
           title: 'Successfully rated',
           description: 'Thanks for rating!',

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
@@ -26,15 +26,20 @@ function getPhotoReference(restaurant) {
   return restaurant.photos ? restaurant.photos[0].photo_reference : null;
 }
 
-export default function ExperienceInfo({ onSubmit }) {
+export default function ExperienceInfo({ onUpdateRestaurants }) {
   const { username } = useContext(UserContext);
   const { restaurants } = useContext(AdventurerContext);
+  // All feedback information (including distance, which is not rateable)
   const feedbackInfo = useContext(FeedbackContext);
   const [indexRestaurant, setIndexRestaurant] = useState(0);
   const [newReview, setNewReview] = useState([]);
   // Get the restaurant viewing now
   const currentRestaurant = restaurants.length > 0 ? restaurants[indexRestaurant] : null;
-  const isRated = currentRestaurant?.review != null;
+  // QUESTION: Why is it not responding to changes (derived state)
+  // currentRestaurant.review not updating
+  let isRated = currentRestaurant ? currentRestaurant.review != null : false;
+  console.log(currentRestaurant);
+  console.log(isRated);
   // Get the information for the active feedback areas
   // discarding distance (that is not to be rated forExperience)
   const feedbackAreas = feedbackInfo?.filter((feedback) =>
@@ -46,9 +51,9 @@ export default function ExperienceInfo({ onSubmit }) {
     : null;
 
   function resetRatingForm() {
-    if (currentRestaurant?.activeFeedback) {
-      return currentRestaurant.activeFeedback.map((feedbackId) => ({
-        feedbackId,
+    if (feedbackAreas.length > 0) {
+      return feedbackAreas.map((feedback) => ({
+        feedbackId: feedback.objectId,
         score: 0,
         comment: '',
       }));
@@ -57,7 +62,7 @@ export default function ExperienceInfo({ onSubmit }) {
   }
 
   useEffect(() => {
-    if (isRated) {
+    if (!isRated) {
       setNewReview(resetRatingForm);
     }
   }, [currentRestaurant, setNewReview]);
@@ -91,7 +96,8 @@ export default function ExperienceInfo({ onSubmit }) {
   function onSubmission() {
     submitRate(username, currentRestaurant.place_id, newReview).then((res) => {
       if (res.data) {
-        onSubmit([...restaurants, { ...currentRestaurant, review: newReview }]);
+        isRated = true;
+        onUpdateRestaurants([...restaurants, { ...currentRestaurant, review: newReview }]);
         return toast({
           title: 'Successfully rated',
           description: 'Thanks for rating!',

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
@@ -18,8 +18,11 @@ const API_KEY = process.env.REACT_APP_GOOGLE_MAPS_API_KEY;
 const baseURL = process.env.REACT_APP_BASE_URL;
 
 async function submitRate(username, experienceId, reviews) {
-  const values = { username, experienceId, reviews };
-  return axios.post(`${baseURL}/review/rate`, values);
+  return axios.post(
+    `${baseURL}/adventure/rate`,
+    { reviews },
+    { headers: { username, experienceId } },
+  );
 }
 
 function getPhotoReference(restaurant) {
@@ -36,14 +39,15 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
   // Get the restaurant viewing now
   const currentRestaurant = restaurants.length > 0 ? restaurants[indexRestaurant] : null;
   // QUESTION: Why is it not responding to changes (derived state)
-  // currentRestaurant.review not updating
-  let isRated = currentRestaurant ? currentRestaurant.review != null : false;
-  console.log(currentRestaurant);
-  console.log(isRated);
+  // currentRestaurant.review not updated by setter. Queued. Till when will it be triggered?
+  // Thinking about not a derived state but another independent state for manipulation
+  const isRated = currentRestaurant ? currentRestaurant.review != null : false;
   // Get the information for the active feedback areas
   // discarding distance (that is not to be rated forExperience)
-  const feedbackAreas = feedbackInfo?.filter((feedback) =>
-    feedback.forExperience && currentRestaurant?.activeFeedback.includes(feedback.objectId),
+  const feedbackAreas = feedbackInfo?.filter(
+    (feedback) =>
+      feedback.forExperience &&
+      currentRestaurant?.activeFeedback.includes(feedback.objectId),
   );
   // find the photo reference of that restaurant
   const photoReference = currentRestaurant
@@ -96,8 +100,11 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
   function onSubmission() {
     submitRate(username, currentRestaurant.place_id, newReview).then((res) => {
       if (res.data) {
-        isRated = true;
-        onUpdateRestaurants([...restaurants, { ...currentRestaurant, review: newReview }]);
+        // update value of Restaurants in the useContext
+        onUpdateRestaurants([
+          ...restaurants,
+          { ...currentRestaurant, review: newReview },
+        ]);
         return toast({
           title: 'Successfully rated',
           description: 'Thanks for rating!',

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
@@ -38,9 +38,6 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
   const [newReview, setNewReview] = useState([]);
   // Get the restaurant viewing now
   const currentRestaurant = restaurants.length > 0 ? restaurants[indexRestaurant] : null;
-  // QUESTION: Why is it not responding to changes (derived state)
-  // currentRestaurant.review not updated by setter. Queued. Till when will it be triggered?
-  // Thinking about not a derived state but another independent state for manipulation
   const isRated = currentRestaurant ? currentRestaurant.review != null : false;
   // Get the information for the active feedback areas
   // discarding distance (that is not to be rated forExperience)
@@ -67,7 +64,7 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
     if (!isRated) {
       setNewReview(resetRatingForm);
     }
-  }, [currentRestaurant, setNewReview]);
+  }, [currentRestaurant, setNewReview, isRated]);
 
   function onNewReviewChange(feedbackId, input, value) {
     const array = newReview.map((review) => {
@@ -98,8 +95,8 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
   function onSubmission() {
     submitRate(username, currentRestaurant.place_id, newReview).then((res) => {
       if (res.data) {
-        // update value of Restaurants in the useContext
-        onUpdateRestaurants([...restaurants, { ...currentRestaurant, review: newReview }]);
+        restaurants[indexRestaurant] = { ...restaurants[indexRestaurant], review: newReview };
+        onUpdateRestaurants([...restaurants]);
         return toast({
           title: 'Successfully rated',
           description: 'Thanks for rating!',

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
@@ -47,8 +47,8 @@ export default function ExperienceInfo({ onSubmit }) {
 
   function resetRatingForm() {
     if (currentRestaurant?.activeFeedback) {
-      return currentRestaurant.activeFeedback.map((feedback) => ({
-        feedbackId: feedback.objectId,
+      return currentRestaurant.activeFeedback.map((feedbackId) => ({
+        feedbackId,
         score: 0,
         comment: '',
       }));
@@ -57,7 +57,7 @@ export default function ExperienceInfo({ onSubmit }) {
   }
 
   useEffect(() => {
-    if (!isRated) {
+    if (isRated) {
       setNewReview(resetRatingForm);
     }
   }, [currentRestaurant, setNewReview]);

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/RateExperience.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/RateExperience.jsx
@@ -49,7 +49,14 @@ export default function RateExperience({
           ))}
         </ModalBody>
         <ModalFooter>
-          <Button colorScheme="blue" mr={3} onClick={onSubmit}>
+          <Button
+            colorScheme="blue"
+            mr={3}
+            onClick={() => {
+              onSubmit();
+              onClose();
+            }}
+          >
             Submit
           </Button>
           <Button

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/RateExperience.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/RateExperience.jsx
@@ -41,7 +41,7 @@ export default function RateExperience({
               id={feedback.objectId}
               minValue={feedback.minValue}
               maxValue={feedback.maxValue}
-              step={feedback.step}
+              step={feedback.stepRating}
               defaultValue={feedback.defaultValue}
               feedbackName={feedback.displayText}
               onChange={onChange}


### PR DESCRIPTION
HI everyone!

This PR includes the necessary changes to have a review request aligned with the proposed format.

In the original code I had one request for submitting  a rate and I decided to keep it that way and just restructuring basic information.

For instance, what I did:

QUERIES/ADVENTURE.JS
I included a query for that specific endpoint 

ROUTES/ADVENTURE.JS
I consume the same query according to the params passed by the UI

ROUTES/REVIEW.JS
I deleted the unused endpoint

ADVENTURER.JSX
I tried to choose a better name for the setter of restaurants. My idea was to use that setter, so that once I submit a review and I get a confirmation status for that request, I would edit my restaurants array and add a review field (so it would update and display this review sign instead of the review button)
![image](https://user-images.githubusercontent.com/60989884/182559899-01ba8f52-0e0d-4cb3-997d-b2d96e079078.png)

QUESTION:
I was trying to have the original version where after the submission was done, it would update immediately from the Rate me button to the rated tag. 
My first approach was to have this derived state from the currentRestaurant, so that on every render it would check the value and then I would only need to update the information of that restaurant with my setter.
However, I see that this approach is not working unless I refresh the page (by that point is being modify by external factors). My assumption up to this moment is that it is related on the queued property that the setter has (not immediate update), but I am still reflecting on what it can be. I will keep you posted if I come up with a solution, and any hint would be appreciated 😅
A (probably not so good) solution I was thinking was instead of having a derived state, creating it's own state so I could manipulate isRated 'easier'. However I believe that could lead to async problems, and that was the point of having a derived state.

