### PR TITLE
Refactor BackEnd for Adventurer on Update Preferences

### DIFF
--- a/back/queries/adventure.js
+++ b/back/queries/adventure.js
@@ -84,6 +84,7 @@ async function UpdatePreferenceQuery(username, prioritize, activeIDs, minValues,
       .save();
       return true;
     } catch (error) {
+      console.error(error);
       return false;
     }
 }

--- a/back/queries/adventure.js
+++ b/back/queries/adventure.js
@@ -68,9 +68,30 @@ async function RateQuery(reviews, username, experienceId) {
   return hasError;
 }
 
+// Update preferences query
+// Used by routes/adventure/preferences/update
+async function UpdatePreferenceQuery(username, prioritize, activeIDs, minValues, hasMinValues) {
+    // Find objectId of the current userPreference entry
+    const objectId = (await new Parse.Query('UserPreference').equalTo('username', username).first()).toJSON().objectId
+    // Update information for that user
+    try {
+      await new Parse.Object('UserPreference')
+      .set('objectId', objectId)
+      .set('prioritize', prioritize)
+      .set('activePreferences', activeIDs)
+      .set('minValues', minValues)
+      .set('hasMinimumValue', hasMinValues)
+      .save();
+      return true;
+    } catch (error) {
+      return false;
+    }
+}
+
 exports.ExperienceReviewsQuery = ExperienceReviewsQuery;
 exports.UserPreferencesQuery = UserPreferencesQuery;
 exports.AllFeedbackInfoQuery = AllFeedbackInfoQuery;
 exports.UserReviewsQuery = UserReviewsQuery;
 exports.ExperiencesQuery = ExperiencesQuery;
 exports.RateQuery = RateQuery;
+exports.UpdatePreferenceQuery = UpdatePreferenceQuery

--- a/back/routes/adventure.js
+++ b/back/routes/adventure.js
@@ -187,19 +187,11 @@ router.post('/rate', async (req, res) => {
   res.status(200).send(hasError);
 });
 
-/* 
-    
-----------------------------------------------------
-            NOT CHANGE YET !!!
-----------------------------------------------------
-*/
-
-// TODO: Refactor code. This still works this way
 // ----- Update user's preferences ------
 router.post('/preferences/update', async (req, res) => {
   // Find objectId of the current user preference
   const findQuery = new Parse.Query('UserPreference');
-  findQuery.equalTo('username', req.body.username);
+  findQuery.equalTo('username', req.headers.username);
   let objectId = null;
   let currentPreferences = await findQuery.first();
   objectId = currentPreferences.toJSON().objectId;
@@ -219,6 +211,13 @@ router.post('/preferences/update', async (req, res) => {
     res.send(false).status(400);
   }
 });
+
+/* 
+    
+----------------------------------------------------
+            NOT CHANGE YET !!!
+----------------------------------------------------
+*/
 
 // ----- Get priorization preferences -----
 router.post('/preferences/prioritize', async (req, res) => {

--- a/back/routes/adventure.js
+++ b/back/routes/adventure.js
@@ -6,6 +6,7 @@ const {
   UserReviewsQuery,
   ExperiencesQuery,
   RateQuery,
+  UpdatePreferenceQuery,
 } = require('../queries/adventure');
 const { filterAndRank } = require('../functions/adventure');
 var express = require('express');
@@ -189,27 +190,8 @@ router.post('/rate', async (req, res) => {
 
 // ----- Update user's preferences ------
 router.post('/preferences/update', async (req, res) => {
-  // Find objectId of the current user preference
-  const findQuery = new Parse.Query('UserPreference');
-  findQuery.equalTo('username', req.headers.username);
-  let objectId = null;
-  let currentPreferences = await findQuery.first();
-  objectId = currentPreferences.toJSON().objectId;
-  // Update information for that user
-  let updateQuery = new Parse.Object('UserPreference');
-  updateQuery.set('objectId', objectId);
-  // Determine what fields the user submitted to update them (if not found, that field remains as recorded in the db)
-  updateQuery.set('prioritize', req.body.prioritize);
-  updateQuery.set('activePreferences', req.body.activeIDs);
-  updateQuery.set('minValues', req.body.minValues);
-  updateQuery.set('hasMinimumValue', req.body.hasMinValues);
-  try {
-    await updateQuery.save();
-    res.status(200);
-    res.send(true);
-  } catch (error) {
-    res.send(false).status(400);
-  }
+  const isUpdated = await UpdatePreferenceQuery(req.headers.username, req.body.prioritize, req.body.activeIDs, req.body.minValues, req.body.hasMinValues)
+  res.status(200).send(isUpdated);
 });
 
 /* 

--- a/capstone/src/components/User/Adventurer/Adventurer.jsx
+++ b/capstone/src/components/User/Adventurer/Adventurer.jsx
@@ -71,7 +71,9 @@ export default function Adventurer({ setIsLoggedIn, isLoggedIn }) {
       params.page !== 'home' ||
       !username
     ) {
+      // Avoid wasting time if it is not at home, by not looking at restaurants
       setRestaurants([]);
+      getAllFeedbackInfo().then((res) => setFeedbackInfo(res.data));
     } else {
       Promise.all([
         getNearbyRestaurants(

--- a/capstone/src/components/User/Adventurer/Preference/Preference.jsx
+++ b/capstone/src/components/User/Adventurer/Preference/Preference.jsx
@@ -32,7 +32,7 @@ export default function Preference() {
     onChangeHasMinValue,
     onChangeMinValue,
   } = useSettings(userType, username);
-  if (!feedbackInfo) return <h2>Loading</h2>;
+  if (!feedbackInfo || feedbackInfo.length === 0) return <h2>Loading</h2>;
   // Find the information of the active and inactive IDs
   // Map function so it respects the order it is in
   const activeInfo = activeIDs.map((ID) =>

--- a/capstone/src/components/User/useSettings.jsx
+++ b/capstone/src/components/User/useSettings.jsx
@@ -38,8 +38,8 @@ async function getBoolMinValues(username) {
   return axios.post(`${baseURL}${preferenceBaseURL}/active/hasMinimum`, values);
 }
 
-async function update(form, URL) {
-  return axios.post(URL.update, form);
+async function update(form, username, URL) {
+  return axios.post(`${baseURL}/adventure/preferences/update`, form, { headers: { username } });
 }
 
 // ONLY FOR ADVENTURER
@@ -169,12 +169,12 @@ export default function useSettings(userType, username) {
     if (isAdventurer) {
       update(
         {
-          username,
           prioritize,
           activeIDs,
           minValues: minPreferenceValues,
           hasMinValues,
         },
+        username,
         URL,
       ).then((res) => submissionMessage(res.data));
     } else {


### PR DESCRIPTION
Hi everyone!

Happy to share this PR for another one of the 6 endpoints.

I previously had the update endpoint working. Most of the changes were related to format: moving the query to its folder, using the chaining property for the Parse Query, passing the username through headers and changing the way the front requests for the data.

I also found a small bug that didn't let me open the preferences page if I didn't pass through home. I discovered that with the new implementation, I made sure to call the function that retrieves all existing feedback in the Promise.all on Adventurer.jsx line 78. However, the intention was that if restaurants are not being used (like when you modify your preferences), that is not requested.

So, I also added the function that calls the feedback information on the conditional in that same file, where params.page != home

Thanks in advance for the feedback!!