### PR TITLE
included endpoint for minValues, hasMinVlaues and prioritize

### DIFF
--- a/back/queries/adventure.js
+++ b/back/queries/adventure.js
@@ -11,7 +11,7 @@ async function ExperienceReviewsQuery(experienceID, feedbackID) {
 }
 
 // Get active UsersPreferences fields
-// Used by routes/adventure/restaurants
+// Used by routes/adventure/restaurants, routes/adventure/preferences/restrictions
 async function UserPreferencesQuery(username) {
   return (
     await new Parse.Query('UserPreference')

--- a/back/routes/adventure.js
+++ b/back/routes/adventure.js
@@ -169,9 +169,15 @@ router.get('/preferences/status', async (req, res) => {
     const inactivePreferencesIDs = inactivePreferences.map(
       (preference) => preference.objectId,
     );
-    res.status(200).send({ active: activePreferencesIDs, inactive: inactivePreferencesIDs });
+    res
+      .status(200)
+      .send({ active: activePreferencesIDs, inactive: inactivePreferencesIDs });
   } else {
-    res.status(400).send({ error: { message: 'No existing preferences record for that user' }});
+    res
+      .status(400)
+      .send({
+        error: { message: 'No existing preferences record for that user' },
+      });
   }
 });
 
@@ -188,80 +194,35 @@ router.post('/rate', async (req, res) => {
   res.status(200).send(hasError);
 });
 
+// -_-_-_-_-_-_-_ENDPOINT_-_-_-_-_-_-_-_-_-_
 // ----- Update user's preferences ------
+// Used in useSettings.jsx
+// Returns a bool with update status
 router.post('/preferences/update', async (req, res) => {
-  const isUpdated = await UpdatePreferenceQuery(req.headers.username, req.body.prioritize, req.body.activeIDs, req.body.minValues, req.body.hasMinValues)
+  const isUpdated = await UpdatePreferenceQuery(
+    req.headers.username,
+    req.body.prioritize,
+    req.body.activeIDs,
+    req.body.minValues,
+    req.body.hasMinValues,
+  );
   res.status(200).send(isUpdated);
 });
 
-/* 
+// -_-_-_-_-_-_-_ENDPOINT_-_-_-_-_-_-_-_-_-_
+// ----- Preferences restrictions ------
+// Used in useSettings.jsx
+// Returns priorization (bool indicating if ranking algorithm is active), minValues (array of values) and hasMinValues (array of bools stating if the minValue is active - to filter)
+// Format: {prioritize, minValues, hasMinimumValue}
+router.get('/preferences/restrictions', async (req, res) => {
+  const preference = await UserPreferencesQuery(req.headers.username);
+  res
+    .status(200)
+    .send({
+      prioritize: preference.prioritize,
+      minValues: preference.minValues,
+      hasMinimumValue: preference.hasMinimumValue,
+    });
+});
     
-----------------------------------------------------
-            NOT CHANGE YET !!!
-----------------------------------------------------
-*/
-
-// ----- Get priorization preferences -----
-router.post('/preferences/prioritize', async (req, res) => {
-  const preference = await UserPreferencesQuery(req.body.username);
-  res.status(200).send(preference.prioritize);
-});
-
-// ----- Get active user's preferences IDs -----
-router.post('/preferences/active', async (req, res) => {
-  const preference = await UserPreferencesQuery(req.body.username);
-  res.status(200).send(preference.activePreferences);
-});
-
-// ----- Get active preferences' minimum values -----
-router.post('/preferences/active/values', async (req, res) => {
-  const preference = await UserPreferencesQuery(req.body.username);
-  res.status(200).send(preference.minValues);
-});
-
-// ----- Get validation for minimum values -----
-router.post('/preferences/active/hasMinimum', async (req, res) => {
-  const preference = await UserPreferencesQuery(req.body.username);
-  res.status(200).send(preference.hasMinimumValue);
-});
-
-// ----- Get all inactive preferences IDS -----
-router.post('/preferences/inactive', async (req, res) => {
-  // Find current preferences
-  let userPreferences = await UserPreferencesQuery(req.body.username);
-  if (userPreferences != null) {
-    let activePreferences = [];
-    activePreferences = userPreferences.activePreferences;
-    // Get all possible preferences
-    const allPreferencesQuery = new Parse.Query('Preference');
-    let allPreferences = null;
-    allPreferences = await allPreferencesQuery.find();
-    // Find inactive preferences IDS
-    let inactivePreferences = allPreferences.filter(
-      (preference) => !activePreferences.includes(preference.toJSON().objectId),
-    );
-    const inactivePreferencesJSON = inactivePreferences.map(
-      (preference) => preference.toJSON().objectId,
-    );
-    res.status(200);
-    res.send(inactivePreferencesJSON);
-  }
-});
-
-// ----- Get preferences information of a given array -----
-router.post('/preferences/info', async (req, res) => {
-  let preferenceInformation = [];
-  const query = new Parse.Query('Preference');
-  let allPreferences = [];
-  allPreferences = await query.find();
-  preferenceInformation = req.body.IDs.map((id) =>
-    allPreferences.find((preference) => preference.toJSON().objectId === id),
-  );
-  preferenceInformationJSON = preferenceInformation.map((preference) =>
-    preference.toJSON(),
-  );
-  res.status(200);
-  res.send(preferenceInformationJSON);
-});
-
 module.exports = router;

--- a/capstone/src/components/User/useSettings.jsx
+++ b/capstone/src/components/User/useSettings.jsx
@@ -26,29 +26,15 @@ async function getPreferenceStatusIDs(username, URL) {
   });
 }
 
-// ONLY FOR ADVENTURER
-async function getActiveMinValues(username) {
-  const values = { username };
-  return axios.post(`${baseURL}${preferenceBaseURL}/active/values`, values);
-}
-
-// ONLY FOR ADVENTURERS
-async function getBoolMinValues(username) {
-  const values = { username };
-  return axios.post(`${baseURL}${preferenceBaseURL}/active/hasMinimum`, values);
-}
-
 async function update(form, username, URL) {
   return axios.post(`${baseURL}/adventure/preferences/update`, form, { headers: { username } });
 }
 
 // ONLY FOR ADVENTURER
-async function getPriorization(username, userType) {
-  if (userType === 'adventurer') {
-    const values = { username };
-    return axios.post(`${baseURL}${preferenceBaseURL}/prioritize`, values);
-  }
-  return { res: { data: false } };
+async function getPreferenceRestrictions(username) {
+  return axios.get(`${baseURL}/adventure/preferences/restrictions`, {
+    headers: { username },
+  });
 }
 
 export default function useSettings(userType, username) {
@@ -74,17 +60,12 @@ export default function useSettings(userType, username) {
         setActiveIDs(res.data.active);
         setInactiveIDs(res.data.inactive);
       });
-      // ONLY FOR ADVENTURER
       if (isAdventurer) {
-        getPriorization(username, userType).then((res) =>
-          setPrioritize(res.data),
-        );
-        // ONLY FOR ADVENTURER
-        getActiveMinValues(username).then((res) =>
-          setMinPreferenceValues(res.data),
-        );
-        // ONLY FOR ADVENTURER
-        getBoolMinValues(username).then((res) => setHasMinValues(res.data));
+        getPreferenceRestrictions(username).then((res) => {
+          setPrioritize(res.data.prioritize);
+          setMinPreferenceValues(res.data.minValues);
+          setHasMinValues(res.data.hasMinimumValue);
+        });
       }
     }
   }, [


### PR DESCRIPTION
Hi everyone! 

So happy to share with you the last endpoint modification for the Adventurer.

I basically just joined the three endpoints into a single call. It was easier because I reused one of the queries I already had (so happy I am not repeating!), and what I was doing before was basically doing the same query to get the userPreference but extract a specific field. Now, it only needs to call for the information once, and I pass the three attributes and deal with that in the front. 

Since the structure on the custom hook was well organize (to the best of my knowledge), I only had to call the setter for the different fields, nothing unreachable now that I am able to use .then calls more confidently (small parenthesis to thank you for every time you both were so patiently explaining me async functions and promises)

NEXT STEPS:
Right now the adventurer part is fully functional to what I had delivered by the end of the MVP. Now I only need to catch up refactoring the Experience Back end.
Having the knowledge I just got from refactoring Adventurer (which I think was the most complex) I hope it won't take me that long, so I can start adding some stretch features.

Happy to hear any feedback!