### PR TITLE
Refactor EXP get Preferences

### DIFF
--- a/back/queries/adventure.js
+++ b/back/queries/adventure.js
@@ -11,7 +11,7 @@ async function ExperienceReviewsQuery(experienceID, feedbackID) {
 }
 
 // Get active UsersPreferences fields
-// Used by routes/adventure/restaurants
+// Used by routes/adventure/restaurants, routes/adventure/preferences/restrictions
 async function UserPreferencesQuery(username) {
   return (
     await new Parse.Query('UserPreference')

--- a/back/queries/experience.js
+++ b/back/queries/experience.js
@@ -1,0 +1,11 @@
+const { Parse } = require('./../parse');
+
+// Get all existing feedback that is available for Experience
+// Used by routes/experience/preferences/all
+async function AllFeedbackInfoQuery() {
+  return (await new Parse.Query('Preference').equalTo('forExperience', true).find()).map((preference) =>
+    preference.toJSON(),
+  );
+}
+
+exports.AllFeedbackInfoQuery = AllFeedbackInfoQuery;

--- a/back/routes/adventure.js
+++ b/back/routes/adventure.js
@@ -169,9 +169,15 @@ router.get('/preferences/status', async (req, res) => {
     const inactivePreferencesIDs = inactivePreferences.map(
       (preference) => preference.objectId,
     );
-    res.status(200).send({ active: activePreferencesIDs, inactive: inactivePreferencesIDs });
+    res
+      .status(200)
+      .send({ active: activePreferencesIDs, inactive: inactivePreferencesIDs });
   } else {
-    res.status(400).send({ error: { message: 'No existing preferences record for that user' }});
+    res
+      .status(400)
+      .send({
+        error: { message: 'No existing preferences record for that user' },
+      });
   }
 });
 
@@ -188,80 +194,35 @@ router.post('/rate', async (req, res) => {
   res.status(200).send(hasError);
 });
 
+// -_-_-_-_-_-_-_ENDPOINT_-_-_-_-_-_-_-_-_-_
 // ----- Update user's preferences ------
+// Used in useSettings.jsx
+// Returns a bool with update status
 router.post('/preferences/update', async (req, res) => {
-  const isUpdated = await UpdatePreferenceQuery(req.headers.username, req.body.prioritize, req.body.activeIDs, req.body.minValues, req.body.hasMinValues)
+  const isUpdated = await UpdatePreferenceQuery(
+    req.headers.username,
+    req.body.prioritize,
+    req.body.activeIDs,
+    req.body.minValues,
+    req.body.hasMinValues,
+  );
   res.status(200).send(isUpdated);
 });
 
-/* 
+// -_-_-_-_-_-_-_ENDPOINT_-_-_-_-_-_-_-_-_-_
+// ----- Preferences restrictions ------
+// Used in useSettings.jsx
+// Returns priorization (bool indicating if ranking algorithm is active), minValues (array of values) and hasMinValues (array of bools stating if the minValue is active - to filter)
+// Format: {prioritize, minValues, hasMinimumValue}
+router.get('/preferences/restrictions', async (req, res) => {
+  const preference = await UserPreferencesQuery(req.headers.username);
+  res
+    .status(200)
+    .send({
+      prioritize: preference.prioritize,
+      minValues: preference.minValues,
+      hasMinimumValue: preference.hasMinimumValue,
+    });
+});
     
-----------------------------------------------------
-            NOT CHANGE YET !!!
-----------------------------------------------------
-*/
-
-// ----- Get priorization preferences -----
-router.post('/preferences/prioritize', async (req, res) => {
-  const preference = await UserPreferencesQuery(req.body.username);
-  res.status(200).send(preference.prioritize);
-});
-
-// ----- Get active user's preferences IDs -----
-router.post('/preferences/active', async (req, res) => {
-  const preference = await UserPreferencesQuery(req.body.username);
-  res.status(200).send(preference.activePreferences);
-});
-
-// ----- Get active preferences' minimum values -----
-router.post('/preferences/active/values', async (req, res) => {
-  const preference = await UserPreferencesQuery(req.body.username);
-  res.status(200).send(preference.minValues);
-});
-
-// ----- Get validation for minimum values -----
-router.post('/preferences/active/hasMinimum', async (req, res) => {
-  const preference = await UserPreferencesQuery(req.body.username);
-  res.status(200).send(preference.hasMinimumValue);
-});
-
-// ----- Get all inactive preferences IDS -----
-router.post('/preferences/inactive', async (req, res) => {
-  // Find current preferences
-  let userPreferences = await UserPreferencesQuery(req.body.username);
-  if (userPreferences != null) {
-    let activePreferences = [];
-    activePreferences = userPreferences.activePreferences;
-    // Get all possible preferences
-    const allPreferencesQuery = new Parse.Query('Preference');
-    let allPreferences = null;
-    allPreferences = await allPreferencesQuery.find();
-    // Find inactive preferences IDS
-    let inactivePreferences = allPreferences.filter(
-      (preference) => !activePreferences.includes(preference.toJSON().objectId),
-    );
-    const inactivePreferencesJSON = inactivePreferences.map(
-      (preference) => preference.toJSON().objectId,
-    );
-    res.status(200);
-    res.send(inactivePreferencesJSON);
-  }
-});
-
-// ----- Get preferences information of a given array -----
-router.post('/preferences/info', async (req, res) => {
-  let preferenceInformation = [];
-  const query = new Parse.Query('Preference');
-  let allPreferences = [];
-  allPreferences = await query.find();
-  preferenceInformation = req.body.IDs.map((id) =>
-    allPreferences.find((preference) => preference.toJSON().objectId === id),
-  );
-  preferenceInformationJSON = preferenceInformation.map((preference) =>
-    preference.toJSON(),
-  );
-  res.status(200);
-  res.send(preferenceInformationJSON);
-});
-
 module.exports = router;

--- a/back/routes/adventure.js
+++ b/back/routes/adventure.js
@@ -1,5 +1,4 @@
 require('dotenv/config');
-const { Parse } = require('./../parse');
 const {
   UserPreferencesQuery,
   AllFeedbackInfoQuery,

--- a/back/routes/experience.js
+++ b/back/routes/experience.js
@@ -1,7 +1,26 @@
 require('dotenv/config');
 var express = require('express');
-var router = express.Router();
 const { Parse } = require('./../parse');
+const {
+  AllFeedbackInfoQuery,
+} = require('../queries/experience');
+var router = express.Router();
+
+// ----- Get feedback information of a given array -----
+router.get('/preferences/all', async (req, res) => {
+  const allFeedbackInfo = await AllFeedbackInfoQuery();
+  res.status(200).send(allFeedbackInfo);
+});
+
+/* 
+---------------------------
+---------------------------
+---------------------------
+OLD VERSION
+---------------------------
+---------------------------
+----------------------------
+*/
 
 // ----- Get the experience the user owns -----
 router.post('/info', async (req, res) => {

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
@@ -38,9 +38,6 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
   const [newReview, setNewReview] = useState([]);
   // Get the restaurant viewing now
   const currentRestaurant = restaurants.length > 0 ? restaurants[indexRestaurant] : null;
-  // QUESTION: Why is it not responding to changes (derived state)
-  // currentRestaurant.review not updated by setter. Queued. Till when will it be triggered?
-  // Thinking about not a derived state but another independent state for manipulation
   const isRated = currentRestaurant ? currentRestaurant.review != null : false;
   // Get the information for the active feedback areas
   // discarding distance (that is not to be rated forExperience)
@@ -67,7 +64,7 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
     if (!isRated) {
       setNewReview(resetRatingForm);
     }
-  }, [currentRestaurant, setNewReview]);
+  }, [currentRestaurant, setNewReview, isRated]);
 
   function onNewReviewChange(feedbackId, input, value) {
     const array = newReview.map((review) => {
@@ -98,8 +95,8 @@ export default function ExperienceInfo({ onUpdateRestaurants }) {
   function onSubmission() {
     submitRate(username, currentRestaurant.place_id, newReview).then((res) => {
       if (res.data) {
-        // update value of Restaurants in the useContext
-        onUpdateRestaurants([...restaurants, { ...currentRestaurant, review: newReview }]);
+        restaurants[indexRestaurant] = { ...restaurants[indexRestaurant], review: newReview };
+        onUpdateRestaurants([...restaurants]);
         return toast({
           title: 'Successfully rated',
           description: 'Thanks for rating!',

--- a/capstone/src/components/User/Experience/Feedback/Feedback.jsx
+++ b/capstone/src/components/User/Experience/Feedback/Feedback.jsx
@@ -6,14 +6,26 @@ import UserContext from '../../../../Contexts/UserContext';
 import useSettings from '../../useSettings';
 import SelectMenu from '../../SelectMenu';
 import SettingsControls from '../../SettingsControls';
+import FeedbackContext from '../../../../Contexts/FeedbackContext';
 
 export default function Feedback() {
   const { username, userType } = useContext(UserContext);
+  // All feedback information (including distance, which is not rateable)
+  const feedbackInfo = useContext(FeedbackContext);
   if (username == null || userType == null) return <h2>Loading...</h2>;
   const {
-    activeInfo, inactiveInfo, onAdd, onDelete, onSubmission,
+    activeIDs, inactiveIDs, onAdd, onDelete, onSubmission,
   } = useSettings(userType, username);
-  const hasMinFeedback = Object.keys(activeInfo).length >= 5;
+
+  const hasMinFeedback = activeIDs.length >= 5;
+  // Find the information of the active and inactive IDs
+  // Map function so it respects the order it is in
+  const activeInfo = activeIDs.map((ID) =>
+    feedbackInfo.find((feedback) => ID === feedback.objectId),
+  );
+  const inactiveInfo = feedbackInfo.filter((feedback) =>
+    inactiveIDs.includes(feedback.objectId),
+  );
   return (
     <Box justifyContent="center" width="50%" textAlign="center">
       <Heading mb="20px"> Why do you want to be remembered? </Heading>

--- a/capstone/src/components/User/useSettings.jsx
+++ b/capstone/src/components/User/useSettings.jsx
@@ -26,29 +26,15 @@ async function getPreferenceStatusIDs(username, URL) {
   });
 }
 
-// ONLY FOR ADVENTURER
-async function getActiveMinValues(username) {
-  const values = { username };
-  return axios.post(`${baseURL}${preferenceBaseURL}/active/values`, values);
-}
-
-// ONLY FOR ADVENTURERS
-async function getBoolMinValues(username) {
-  const values = { username };
-  return axios.post(`${baseURL}${preferenceBaseURL}/active/hasMinimum`, values);
-}
-
 async function update(form, username, URL) {
   return axios.post(`${baseURL}/adventure/preferences/update`, form, { headers: { username } });
 }
 
 // ONLY FOR ADVENTURER
-async function getPriorization(username, userType) {
-  if (userType === 'adventurer') {
-    const values = { username };
-    return axios.post(`${baseURL}${preferenceBaseURL}/prioritize`, values);
-  }
-  return { res: { data: false } };
+async function getPreferenceRestrictions(username) {
+  return axios.get(`${baseURL}/adventure/preferences/restrictions`, {
+    headers: { username },
+  });
 }
 
 export default function useSettings(userType, username) {
@@ -74,17 +60,12 @@ export default function useSettings(userType, username) {
         setActiveIDs(res.data.active);
         setInactiveIDs(res.data.inactive);
       });
-      // ONLY FOR ADVENTURER
       if (isAdventurer) {
-        getPriorization(username, userType).then((res) =>
-          setPrioritize(res.data),
-        );
-        // ONLY FOR ADVENTURER
-        getActiveMinValues(username).then((res) =>
-          setMinPreferenceValues(res.data),
-        );
-        // ONLY FOR ADVENTURER
-        getBoolMinValues(username).then((res) => setHasMinValues(res.data));
+        getPreferenceRestrictions(username).then((res) => {
+          setPrioritize(res.data.prioritize);
+          setMinPreferenceValues(res.data.minValues);
+          setHasMinValues(res.data.hasMinimumValue);
+        });
       }
     }
   }, [

--- a/capstone/src/components/User/useSettings.jsx
+++ b/capstone/src/components/User/useSettings.jsx
@@ -3,17 +3,17 @@ import { useState, useEffect } from 'react';
 import { useToast } from '@chakra-ui/react';
 
 const baseURL = process.env.REACT_APP_BASE_URL;
-const preferenceBaseURL = '/adventure/preferences';
-const feedbackBaseURL = '/experience/feedback';
+const adventurerURL = '/adventure/preferences';
+const experienceURL = '/experience/preferences';
 
 function defineURL(userType) {
-  const KeysURL = ['inactive', 'active', 'info', 'update'];
+  const KeysURL = ['status', 'update'];
   const URL = {};
   KeysURL.forEach((key) => {
     if (userType === 'adventurer') {
-      URL[key] = `${baseURL}${preferenceBaseURL}/${key}`;
+      URL[key] = `${baseURL}${adventurerURL}/${key}`;
     } else {
-      URL[key] = `${baseURL}${feedbackBaseURL}/${key}`;
+      URL[key] = `${baseURL}${experienceURL}/${key}`;
     }
   });
   return URL;
@@ -21,18 +21,18 @@ function defineURL(userType) {
 
 // TODO: Adapt URL when work done with Experience's back
 async function getPreferenceStatusIDs(username, URL) {
-  return axios.get(`${baseURL}/adventure/preferences/status`, {
+  return axios.get(URL.status, {
     headers: { username },
   });
 }
 
 async function update(form, username, URL) {
-  return axios.post(`${baseURL}/adventure/preferences/update`, form, { headers: { username } });
+  return axios.post(URL.update, form, { headers: { username } });
 }
 
 // ONLY FOR ADVENTURER
 async function getPreferenceRestrictions(username) {
-  return axios.get(`${baseURL}/adventure/preferences/restrictions`, {
+  return axios.get(`${baseURL}${adventurerURL}/restrictions`, {
     headers: { username },
   });
 }


### PR DESCRIPTION
Hi everyone!

This is another PR.

In general the changes I made include:

Created the query for getting the feedback areas where Experience Makers want to be rated in **queries/experience.js**
- (distance is excluded, that is out of their control)

Deleted 

I call the query for getting those feedback areas in **routes/experience.js**

In **ExperienceInfo.jsx** I decided to include the solution for that problem where after rating an experience it was not automatically displaying the rated label, so I could have in this branch the most functional version and I didn't have to wait until all PR were approved.

**Experience.jsx** was about calling my endpoint for getting feedback areas and use the useContext to pass it down.

On **Feedback.jsx** I consume the the context, I pass down the active and inactiveIDs array, and I am pretending to retrieve the information of those IDs with the feedback context (that will be in the following PR that looks into that).

On the **useSettings.jsx** I just modify the URL that will be in charge of making the requests.


