### PR TITLE
Refactor Back Experience get Experience Information

### DIFF
--- a/back/queries/experience.js
+++ b/back/queries/experience.js
@@ -10,7 +10,8 @@ async function AllFeedbackInfoQuery() {
 
 // Get all records of an experience
 // Used by 
-// -> routes/experience/preferences/status, 
+// -> routes/experience/info
+// -> routes/experience/preferences/status
 // -> routes/experience/preferences/update
 async function ExperienceInfoQuery(username) {
   return (await new Parse.Query('Experience').equalTo('username', username).first()).toJSON();

--- a/back/routes/experience.js
+++ b/back/routes/experience.js
@@ -45,6 +45,13 @@ router.get('/preferences/status', async (req, res) => {
 });
 
 // -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+// ----- Get the information of an experience that user X owns -----
+router.get('/info', async (req, res) => {
+  const experienceInfo = await ExperienceInfoQuery(req.headers.username);
+  res.status(200).send(experienceInfo);
+});
+
+// -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
 // ----- Submit feedback preferences to db -----
 router.post('/preferences/update', async (req, res) => {
   const objectId = (await ExperienceInfoQuery(req.headers.username)).objectId;
@@ -61,14 +68,6 @@ OLD VERSION
 ---------------------------
 ----------------------------
 */
-
-// ----- Get the experience the user owns -----
-router.post('/info', async (req, res) => {
-  const query = new Parse.Query('Experience');
-  query.equalTo('username', req.body.username);
-  const experienceInfo = await query.first();
-  res.status(200).send(experienceInfo);
-});
 
 // Submit experience information
 router.post('/submit', async (req, res) => {

--- a/capstone/src/components/User/Experience/Experience.jsx
+++ b/capstone/src/components/User/Experience/Experience.jsx
@@ -46,8 +46,8 @@ export default function Experience({ setIsLoggedIn, isLoggedIn }) {
           // send to that page to promote submission.
           // Otherwise, just set values in state
           if (
-            !(Object.keys(expRes.data).every(
-              (experienceFieldID) => expRes.data[experienceFieldID] !== '' || experienceFieldID === 'description',
+            !(Object.entries(expRes.data).every(
+              ([key, value]) => value !== '' || key === 'description',
             ))
           ) {
             navigate('/experience/myExperience', { replace: true });

--- a/capstone/src/components/User/Experience/Experience.jsx
+++ b/capstone/src/components/User/Experience/Experience.jsx
@@ -13,8 +13,7 @@ import FeedbackContext from '../../../Contexts/FeedbackContext';
 const baseURL = process.env.REACT_APP_BASE_URL;
 
 async function getExperienceInfo(username) {
-  const values = { username };
-  return axios.post(`${baseURL}/experience/info`, values);
+  return axios.get(`${baseURL}/experience/info`, { headers: { username } });
 }
 
 async function getAllFeedbackInfo() {
@@ -45,7 +44,11 @@ export default function Experience({ setIsLoggedIn, isLoggedIn }) {
           // If there are no values for a field
           // send to that page to promote submission.
           // Otherwise, just set values in state
-          if (Object.keys(expRes.data).every((experienceField) => !!experienceField)) {
+          if (
+            Object.keys(expRes.data).every(
+              (experienceFieldID) => !expRes.data[experienceFieldID],
+            )
+          ) {
             navigate('/experience/myExperience', { replace: true });
           } else {
             setExperienceData(expRes.data);

--- a/capstone/src/components/User/Experience/Experience.jsx
+++ b/capstone/src/components/User/Experience/Experience.jsx
@@ -41,17 +41,16 @@ export default function Experience({ setIsLoggedIn, isLoggedIn }) {
     } else if (username != null) {
       Promise.all([getExperienceInfo(username), getAllFeedbackInfo()]).then(
         ([expRes, feedbackRes]) => {
+          setExperienceData(expRes.data);
           // If there are no values for a field
           // send to that page to promote submission.
           // Otherwise, just set values in state
           if (
-            Object.keys(expRes.data).every(
-              (experienceFieldID) => !expRes.data[experienceFieldID],
-            )
+            !(Object.keys(expRes.data).every(
+              (experienceFieldID) => expRes.data[experienceFieldID] !== '' || experienceFieldID === 'description',
+            ))
           ) {
             navigate('/experience/myExperience', { replace: true });
-          } else {
-            setExperienceData(expRes.data);
           }
           setFeedbackInfo(feedbackRes.data);
           setIsLoading(false);

--- a/capstone/src/components/User/useSettings.jsx
+++ b/capstone/src/components/User/useSettings.jsx
@@ -20,7 +20,6 @@ function defineURL(userType) {
   return URL;
 }
 
-// TODO: Adapt URL when work done with Experience's back
 async function getPreferenceStatusIDs(username, URL) {
   return axios.get(URL.status, {
     headers: { username },

--- a/capstone/src/components/Visitor/Login/Login.jsx
+++ b/capstone/src/components/Visitor/Login/Login.jsx
@@ -14,7 +14,6 @@ export function logIn(formValues) {
 }
 
 export function resetForm(setLogIn) {
-  // TODO: Convenient to map attributes in case of change, applied automatically
   setLogIn({
     username: '',
     password: '',


### PR DESCRIPTION
Hi everyone! 

Almost the last PR of backend refactoring

In general: 

I reused one of the Queries I had for the experience information.
I changed the axios.post for axios.get 
Used the headers for the username
Fixed a problem about how I was calling the experience information to check if all fields are completed (if one is missing), allowing description to be empty since it is not mandatory. 
I erased some TODOs that no longer apply