### PR TITLE
show changes when user rates experience

### DIFF
--- a/back/functions/filterAndRank.js
+++ b/back/functions/filterAndRank.js
@@ -61,7 +61,7 @@ async function filterAndRank(
     let score = 0;
     let passesFilter = true;
     let indexPreference = 0;
-    const reviewsNumber = await getReviews(restaurant.place_id);
+    const reviewsNumber = await getReviews(restaurant.objectId);
     for (const preferenceID of userPreference.activePreferences) {
       const feedbackMaxValue = allFeedbackInfo.find(
         (feedback) => feedback.objectId === preferenceID,
@@ -69,9 +69,10 @@ async function filterAndRank(
       const preferenceName = allFeedbackInfo.find(
         (feedback) => feedback.objectId === preferenceID,
       ).displayText;
-      const meanReviewScore = await getMean(restaurant.place_id, preferenceID);
+      const meanReviewScore = await getMean(restaurant.objectId, preferenceID);
       meanScores.push({
         preferenceName,
+        feedbackId: preferenceID,
         meanReviewScore: (meanReviewScore / feedbackMaxValue) * 100,
       });
       // Find the matching score if the user has priorities
@@ -104,7 +105,7 @@ async function filterAndRank(
           allFeedbackInfo.map((feedback) => feedback.objectId),
         // set review from the user if existing, otherwise undefined
         review: userReviews.find(
-          (review) => review.experienceId === restaurant.place_id,
+          (review) => review.experienceId === restaurant.objectId,
         ),
         reviewsNumber: reviewsNumber,
         meanScores,

--- a/back/routes/adventure.js
+++ b/back/routes/adventure.js
@@ -62,12 +62,18 @@ async function mergeAPIandAppData(restaurant) {
 }
 // ------- Get back4app restaurants -------
 async function getDatabaseRestaurants(distance, userLat, userLng) {
+  const minPreferencesNumber = 5;
   const allRestaurants = await ExperiencesQuery();
   const restaurants = [];
   // IDs that are not allowed to be repeated by google API
   const usedPlaceIDs = [];
   for (const restaurant of allRestaurants) {
-    if (!restaurant.address || restaurant.activeFeedback.length < 5) continue;
+    if (
+      !restaurant.address ||
+      restaurant.activeFeedback.length < minPreferencesNumber
+    ) {
+      continue;
+    }
     // find distance between adventurer and restaurant
     const config = {
       method: 'get',

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
@@ -33,15 +33,24 @@ function getPhotoReference(restaurant) {
   return restaurant.photos ? restaurant.photos[0].photo_reference : null;
 }
 
+/*
+  After submitting a new review, find the new values for the statistics 
+  on a restaurant so the user doesn't have to reload the page
+  for meanReviewScore (the average score for each preference)
+  it finds the accumulated sum of all previous reviews (points out of a 100)
+  and later adds the new review value, to later find the new average.
+*/
 function calculateNewMeanReviews(meanScores, reviewsNumber, newReview) {
+  const maxValue = 5;
   return meanScores.map((scoreObject) => {
-    const newVal = (newReview.find(
+    const newVal = newReview.find(
       (review) => review.feedbackId === scoreObject.feedbackId,
-    )).score;
+    ).score;
     return {
       ...scoreObject,
       meanReviewScore:
-        ((newVal / 5 * 100) + scoreObject.meanReviewScore * reviewsNumber) /
+        ((newVal / maxValue) * 100 +
+          scoreObject.meanReviewScore * reviewsNumber) /
         (reviewsNumber + 1),
     };
   });
@@ -121,12 +130,13 @@ export default function ExperienceInfo({
       if (res.data) {
         restaurants[indexRestaurant] = {
           ...restaurants[indexRestaurant],
+          reviewsNumber: currentRestaurant.reviewsNumber + 1,
           review: newReview,
           meanScores: calculateNewMeanReviews(
             currentRestaurant.meanScores,
             currentRestaurant.reviewsNumber,
             newReview,
-          )
+          ),
         };
         onUpdateRestaurants([...restaurants]);
         toast(

--- a/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
+++ b/capstone/src/components/User/Adventurer/ExperienceInfo/ExperienceInfo.jsx
@@ -33,14 +33,33 @@ function getPhotoReference(restaurant) {
   return restaurant.photos ? restaurant.photos[0].photo_reference : null;
 }
 
-export default function ExperienceInfo({ onUpdateRestaurants, indexRestaurant, onSelectRestaurant }) {
+function calculateNewMeanReviews(meanScores, reviewsNumber, newReview) {
+  return meanScores.map((scoreObject) => {
+    const newVal = (newReview.find(
+      (review) => review.feedbackId === scoreObject.feedbackId,
+    )).score;
+    return {
+      ...scoreObject,
+      meanReviewScore:
+        ((newVal / 5 * 100) + scoreObject.meanReviewScore * reviewsNumber) /
+        (reviewsNumber + 1),
+    };
+  });
+}
+
+export default function ExperienceInfo({
+  onUpdateRestaurants,
+  indexRestaurant,
+  onSelectRestaurant,
+}) {
   const { username } = useContext(UserContext);
   const { restaurants } = useContext(AdventurerContext);
   // All feedback information (including distance, which is not rateable)
   const feedbackInfo = useContext(FeedbackContext);
   const [newReview, setNewReview] = useState([]);
   // Get the restaurant viewing now
-  const currentRestaurant = restaurants.length > 0 ? restaurants[indexRestaurant] : null;
+  const currentRestaurant =
+    restaurants.length > 0 ? restaurants[indexRestaurant] : null;
   const isRated = currentRestaurant ? currentRestaurant.review != null : false;
   // Get the information for the active feedback areas
   // discarding distance (that is not to be rated forExperience)
@@ -98,11 +117,16 @@ export default function ExperienceInfo({ onUpdateRestaurants, indexRestaurant, o
 
   const toast = useToast();
   function onSubmission() {
-    submitRate(username, currentRestaurant.place_id, newReview).then((res) => {
+    submitRate(username, currentRestaurant.objectId, newReview).then((res) => {
       if (res.data) {
         restaurants[indexRestaurant] = {
           ...restaurants[indexRestaurant],
           review: newReview,
+          meanScores: calculateNewMeanReviews(
+            currentRestaurant.meanScores,
+            currentRestaurant.reviewsNumber,
+            newReview,
+          )
         };
         onUpdateRestaurants([...restaurants]);
         toast(
@@ -161,30 +185,30 @@ export default function ExperienceInfo({ onUpdateRestaurants, indexRestaurant, o
           {currentRestaurant.name}
         </Heading>
         <Text>{currentRestaurant.formatted_address}</Text>
-        <Box  width="100%" mt="30px">
+        <Box width="100%" mt="30px">
           <Heading textAlign="center" size="md">
             Statistics:
           </Heading>
           <Text textAlign="center">Ordered according to your preferences</Text>
         </Box>
-          <VStack width="60%" spacing="20px" m="10px">
-            {currentRestaurant.meanScores.map((meanScore) => (
-              <Box
-                width="80%"
-                display="flex"
-                flexDirection="column"
-                alignContent="center"
-              >
-                <Text>{meanScore.preferenceName}</Text>
-                <Progress
-                  height="20px"
-                  width="100%"
-                  value={meanScore.meanReviewScore}
-                  colorScheme="yellow"
-                />
-              </Box>
-            ))}
-          </VStack>
+        <VStack width="60%" spacing="20px" m="10px">
+          {currentRestaurant.meanScores.map((meanScore) => (
+            <Box
+              width="80%"
+              display="flex"
+              flexDirection="column"
+              alignContent="center"
+            >
+              <Text>{meanScore.preferenceName}</Text>
+              <Progress
+                height="20px"
+                width="100%"
+                value={meanScore.meanReviewScore}
+                colorScheme="yellow"
+              />
+            </Box>
+          ))}
+        </VStack>
       </VStack>
     );
   }


### PR DESCRIPTION
Hi everyone! 

I realized I was not displaying the result of the statistics until the user reloads the page. So I decided to implement that as soon as the rating is confirmed.

## DEMO

![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/60989884/184040110-b51928a8-0b26-40f3-8484-cdc772101c41.gif)

## CHANGES

### filterAndRank.js
I was previously using the objectId and the place_id as interchangeable. However, I realized that by doing that, my algorithm was not detecting new ratings to claimedRestaurants. In that sense, I decided to change it all to objectId when it comes to get metrics on an experience, 

### routes/adventure.js
I also included the objectId for the merged objects to be that one that is in Back4app, I decided to catch those experiences with less than 5 preferences here, as well as include an objectId for the restaurants from GoogleAPI: the place_id

### ExperienceInfo.jsx
The biggest change in here corresponds to calculateNewMeanReviews, where I basically, according to the existing and submitting review values, I calculate what the new mean for the feedback will be so that by submitting it, it will update it.